### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.0: QmUKtSzfnSfSWz9rVXcReqJbBkUFbD9W4Aq6zannqxVc4T
+0.1.1: QmZg566m6GTANKnweD63nLao2J5qgFVSKscHqrNyVUzwDA

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSXpwmggGd8fe7e9abqRuST7SqaZjrz3Cg5avMJbdmKGe",
+      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
       "name": "go-testutil",
-      "version": "1.1.8"
+      "version": "1.1.9"
     }
   ],
   "gxVersion": "0.11.0",
@@ -36,6 +36,6 @@
   "license": "",
   "name": "go-libp2p-connmgr",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/11


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace