### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.1: QmZg566m6GTANKnweD63nLao2J5qgFVSKscHqrNyVUzwDA
+0.1.2: QmdjeSxRchVsQ2ftrZyvVmFqoJ1QbJZ2PgugBsZ58TZZqQ

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
+      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
       "name": "go-testutil",
-      "version": "1.1.9"
+      "version": "1.1.10"
     }
   ],
   "gxVersion": "0.11.0",
@@ -36,6 +36,6 @@
   "license": "",
   "name": "go-libp2p-connmgr",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/12


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace