### PR TITLE
faster, cleaner connection closing

### DIFF
--- a/connmgr.go
+++ b/connmgr.go
@@ -31,8 +31,6 @@ type connManager struct {
 
 var _ ifconnmgr.ConnManager = (*connManager)(nil)
 
-var DefaultGracePeriod = time.Second * 10
-
 func NewConnManager(low, hi int, grace time.Duration) ifconnmgr.ConnManager {
 	return &connManager{
 		highWater:   hi,


### PR DESCRIPTION
1. Don't ask the system for the time when checking if we should close each
connection (potentially thousands of systemcalls!).
2. Log from outside the lock.
3. Log the event around the entire connection closing operation.
4. Preallocate the slice holding the connections to be closed.