### PR TITLE
Fix peer tagging

### DIFF
--- a/connmgr.go
+++ b/connmgr.go
@@ -164,8 +164,12 @@ func (cm *BasicConnMgr) TagPeer(p peer.ID, tag string, val int) {
 
 	pi, ok := cm.peers[p]
 	if !ok {
-		log.Info("tried to tag conn from untracked peer: ", p)
-		return
+		pi = &peerInfo{
+			firstSeen: time.Now(),
+			tags:      make(map[string]int),
+			conns:     make(map[inet.Conn]time.Time),
+		}
+		cm.peers[p] = pi
 	}
 
 	// Update the total value of the peer.

--- a/connmgr_test.go
+++ b/connmgr_test.go
@@ -184,8 +184,8 @@ func TestTagPeerNonExistant(t *testing.T) {
 	id := tu.RandPeerIDFatal(t)
 	cm.TagPeer(id, "test", 1)
 
-	if len(cm.peers) != 0 {
-		t.Fatal("expected zero peers")
+	if len(cm.peers) != 1 {
+		t.Fatal("expected 1 peer")
 	}
 }
 


### PR DESCRIPTION
Another routine could observe event `Connected` earlier than `ConnManager` and tag peers, for now, those tags are lost.
Logs like `tried to tag conn from untracked peer: <peer.ID Qm*3JXWfP>` could be found.