### PR TITLE
Dont Use Internal Context, Use Wait Groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,22 @@
-os:
-  - linux
-
 language: go
 
 go:
-  - 1.11.x
+- '1.12'
 
 env:
   global:
-    - GOTFLAGS="-race"
-  matrix:
-    - BUILD_DEPTYPE=gomod
+    - GO111MODULE=on
 
-
-# disable travis install
 install:
-  - true
+- go mod download
+
+before_script:
+- go vet ./...
+- go build ./...
+- go test -run xxxx ./...
 
 script:
-  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+- go test -race -short -coverprofile=coverage.txt ./...
 
-
-cache:
-  directories:
-    - $GOPATH/pkg/mod
-    - $HOME/.cache/go-build
-
-notifications:
-  email: false
+after_success:
+- bash <(curl -s https://codecov.io/bash)

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package connmgr
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"testing"
@@ -16,17 +17,20 @@ func randomConns(tb testing.TB) (c [5000]network.Conn) {
 }
 
 func BenchmarkLockContention(b *testing.B) {
+	wg := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	conns := randomConns(b)
-	cm := NewConnManager(1000, 1000, 0)
+	cm := NewConnManager(ctx, wg, 1000, 1000, 0)
 	not := cm.Notifee()
 
 	kill := make(chan struct{})
-	var wg sync.WaitGroup
+	var wg1 sync.WaitGroup
 
 	for i := 0; i < 16; i++ {
-		wg.Add(1)
+		wg1.Add(1)
 		go func() {
-			defer wg.Done()
+			defer wg1.Done()
 			for {
 				select {
 				case <-kill:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
 coverage:
-  range: "50...100"
-comment: off
+  precision: 2
+  round: up
+  range: "50...90"
+  status:
+    project:
+      default:
+        threshold: 1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libp2p/go-libp2p-connmgr
+module github.com/RTradeLtd/go-libp2p-connmgr
 
 require (
 	github.com/ipfs/go-detect-race v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/RTradeLtd/go-libp2p-connmgr
 
+go 1.12
+
 require (
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-log v0.0.1


### PR DESCRIPTION
* Instead of using an internal context, provide context with the construction.
* Use a sync group with the goroutine 