### PR TITLE
fix: trim connections every gracePeriod/2

### DIFF
--- a/connmgr.go
+++ b/connmgr.go
@@ -189,7 +189,15 @@ func (cm *BasicConnMgr) TrimOpenConns(ctx context.Context) {
 }
 
 func (cm *BasicConnMgr) background() {
-	ticker := time.NewTicker(time.Minute)
+	interval := cm.gracePeriod / 2
+	if interval < cm.silencePeriod {
+		interval = cm.silencePeriod
+	}
+	if interval < 10*time.Second {
+		interval = 10 * time.Second
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
We're still rate-limited to once every 10 seconds. However, this means that setting the grace period to something below one minute actually _does_ something useful.

fixes #51