### PR TITLE
decaying tags: support removal and closure.

### DIFF
--- a/decay_test.go
+++ b/decay_test.go
@@ -283,7 +283,7 @@ func TestResolutionMisaligned(t *testing.T) {
 	// allow the background goroutine to process bumps.
 	<-time.After(500 * time.Millisecond)
 
-	// nothing has happened.
+	// first tick.
 	mockClock.Add(TestResolution)
 	require.Equal(1000, mgr.GetTagInfo(id).Tags["beep"])
 	require.Equal(1000, mgr.GetTagInfo(id).Tags["bop"])
@@ -299,6 +299,104 @@ func TestResolutionMisaligned(t *testing.T) {
 	require.Equal(999, mgr.GetTagInfo(id).Tags["bop"])
 
 	require.Equal(1997, mgr.GetTagInfo(id).Value)
+}
+
+func TestTagRemoval(t *testing.T) {
+	var (
+		id1, id2              = tu.RandPeerIDFatal(t), tu.RandPeerIDFatal(t)
+		mgr, decay, mockClock = testDecayTracker(t)
+		require               = require.New(t)
+	)
+
+	tag1, err := decay.RegisterDecayingTag("beep", TestResolution, connmgr.DecayFixed(1), connmgr.BumpOverwrite())
+	require.NoError(err)
+
+	tag2, err := decay.RegisterDecayingTag("bop", TestResolution, connmgr.DecayFixed(1), connmgr.BumpOverwrite())
+	require.NoError(err)
+
+	// id1 has both tags; id1 only has the first tag.
+	_ = tag1.Bump(id1, 1000)
+	_ = tag2.Bump(id1, 1000)
+	_ = tag1.Bump(id2, 1000)
+
+	// allow the background goroutine to process bumps.
+	<-time.After(500 * time.Millisecond)
+
+	// first tick.
+	mockClock.Add(TestResolution)
+	require.Equal(999, mgr.GetTagInfo(id1).Tags["beep"])
+	require.Equal(999, mgr.GetTagInfo(id1).Tags["bop"])
+	require.Equal(999, mgr.GetTagInfo(id2).Tags["beep"])
+
+	require.Equal(999*2, mgr.GetTagInfo(id1).Value)
+	require.Equal(999, mgr.GetTagInfo(id2).Value)
+
+	// remove tag1 from p1.
+	err = tag1.Remove(id1)
+
+	// allow the background goroutine to process the removal.
+	<-time.After(500 * time.Millisecond)
+	require.NoError(err)
+
+	// next tick. both peers only have 1 tag, both at 998 value.
+	mockClock.Add(TestResolution)
+	require.Zero(mgr.GetTagInfo(id1).Tags["beep"])
+	require.Equal(998, mgr.GetTagInfo(id1).Tags["bop"])
+	require.Equal(998, mgr.GetTagInfo(id2).Tags["beep"])
+
+	require.Equal(998, mgr.GetTagInfo(id1).Value)
+	require.Equal(998, mgr.GetTagInfo(id2).Value)
+
+	// remove tag1 from p1 again; no error.
+	err = tag1.Remove(id1)
+	require.NoError(err)
+}
+
+func TestTagClosure(t *testing.T) {
+	var (
+		id                    = tu.RandPeerIDFatal(t)
+		mgr, decay, mockClock = testDecayTracker(t)
+		require               = require.New(t)
+	)
+
+	tag1, err := decay.RegisterDecayingTag("beep", TestResolution, connmgr.DecayFixed(1), connmgr.BumpOverwrite())
+	require.NoError(err)
+
+	tag2, err := decay.RegisterDecayingTag("bop", TestResolution, connmgr.DecayFixed(1), connmgr.BumpOverwrite())
+	require.NoError(err)
+
+	_ = tag1.Bump(id, 1000)
+	_ = tag2.Bump(id, 1000)
+	// allow the background goroutine to process bumps.
+	<-time.After(500 * time.Millisecond)
+
+	// nothing has happened.
+	mockClock.Add(TestResolution)
+	require.Equal(999, mgr.GetTagInfo(id).Tags["beep"])
+	require.Equal(999, mgr.GetTagInfo(id).Tags["bop"])
+	require.Equal(999*2, mgr.GetTagInfo(id).Value)
+
+	// next tick; tag1 would've ticked.
+	mockClock.Add(TestResolution)
+	require.Equal(998, mgr.GetTagInfo(id).Tags["beep"])
+	require.Equal(998, mgr.GetTagInfo(id).Tags["bop"])
+	require.Equal(998*2, mgr.GetTagInfo(id).Value)
+
+	// close the tag.
+	err = tag1.Close()
+	require.NoError(err)
+
+	// allow the background goroutine to process the closure.
+	<-time.After(500 * time.Millisecond)
+	require.Equal(998, mgr.GetTagInfo(id).Value)
+
+	// a second closure should not error.
+	err = tag1.Close()
+	require.NoError(err)
+
+	// bumping a tag after it's been closed should error.
+	err = tag1.Bump(id, 5)
+	require.Error(err)
 }
 
 func testDecayTracker(tb testing.TB) (*BasicConnMgr, connmgr.Decayer, *clock.Mock) {

--- a/decay_test.go
+++ b/decay_test.go
@@ -314,7 +314,7 @@ func TestTagRemoval(t *testing.T) {
 	tag2, err := decay.RegisterDecayingTag("bop", TestResolution, connmgr.DecayFixed(1), connmgr.BumpOverwrite())
 	require.NoError(err)
 
-	// id1 has both tags; id1 only has the first tag.
+	// id1 has both tags; id2 only has the first tag.
 	_ = tag1.Bump(id1, 1000)
 	_ = tag2.Bump(id1, 1000)
 	_ = tag1.Bump(id2, 1000)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/benbjohnson/clock v1.0.1
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-log v1.0.4
-	github.com/libp2p/go-libp2p-core v0.5.5
+	github.com/libp2p/go-libp2p-core v0.5.6-0.20200514185821-3fd1d20845de
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -55,15 +55,9 @@ github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg
 github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
-github.com/libp2p/go-libp2p-core v0.5.4-0.20200514121551-d3277047d6ca h1:9xF2NgTB7L0GFdRBnEE8sa7sZbeshEznH1pEuqH5A8o=
-github.com/libp2p/go-libp2p-core v0.5.4-0.20200514121551-d3277047d6ca/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
-github.com/libp2p/go-libp2p-core v0.5.5-0.20200514134608-fd0d4abfc174 h1:OID2AvF6Ax15EvUjAsJVbVhhY9CWPA3ub6hSRXk9vxU=
-github.com/libp2p/go-libp2p-core v0.5.5-0.20200514134608-fd0d4abfc174/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
-github.com/libp2p/go-libp2p-core v0.5.5 h1:/yiFUZDoBWqvpWeHHJ1iA8SOs5obT1/+UdNfckwD57M=
-github.com/libp2p/go-libp2p-core v0.5.5/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
+github.com/libp2p/go-libp2p-core v0.5.6-0.20200514185821-3fd1d20845de h1:zkQm/5xoY3kB4nGcYYaJU+Q1NY++qv7C0NjI4ym/kiM=
+github.com/libp2p/go-libp2p-core v0.5.6-0.20200514185821-3fd1d20845de/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
 github.com/libp2p/go-msgio v0.0.4/go.mod h1:63lBBgOTDKQL6EWazRMCwXsEeEeK9O2Cd+0+6OOuipQ=
-github.com/libp2p/go-openssl v0.0.4 h1:d27YZvLoTyMhIN4njrkr8zMDOM4lfpHIp6A+TK9fovg=
-github.com/libp2p/go-openssl v0.0.4/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/libp2p/go-openssl v0.0.5 h1:pQkejVhF0xp08D4CQUcw8t+BFJeXowja6RVcb5p++EA=
 github.com/libp2p/go-openssl v0.0.5/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=


### PR DESCRIPTION
This PR introduces two features to decaying tags:

* Explicitly remove a decaying tag from a peer.
* Kill/close a decaying tag, dropping its tracking and erasing it from all peers.

---

See https://github.com/libp2p/go-libp2p-core/pull/151 for interface changes.