### PR TITLE
Close connections where streams haven't been opened since some time

### DIFF
--- a/connmgr_test.go
+++ b/connmgr_test.go
@@ -139,10 +139,10 @@ func TestTrimJoin(t *testing.T) {
 }
 
 func TestCloseConnsWithNoStreams(t *testing.T) {
-	copy := maxStreamOpenDuration
-	maxStreamOpenDuration = 100 * time.Millisecond
+	copy := connCloseStreamTimeout
+	connCloseStreamTimeout = 100 * time.Millisecond
 	defer func() {
-		maxStreamOpenDuration = copy
+		connCloseStreamTimeout = copy
 	}()
 
 	cm := NewConnManager(5, 8, 0)
@@ -169,10 +169,10 @@ func TestCloseConnsWithNoStreams(t *testing.T) {
 }
 
 func TestDontCloseConnsWithOpenStreams(t *testing.T) {
-	copy := maxStreamOpenDuration
-	maxStreamOpenDuration = 100 * time.Millisecond
+	copy := connCloseStreamTimeout
+	connCloseStreamTimeout = 100 * time.Millisecond
 	defer func() {
-		maxStreamOpenDuration = copy
+		connCloseStreamTimeout = copy
 	}()
 
 	cm := NewConnManager(5, 8, 0)


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/1039.

As discussed with @Stebalien , once hole punching is in place, we could end up with multiple connections between peers often. That's because we'd have the Relayed connection on which the successful hole punch was co-ordinated and for QUIC, we'd simply end up with two connections between the peers during a hole punch.

However, in the Swarm, we'll ONLY open stream on the newest direct connection with the most streams going ahead. So, in the connection manager, we should close Connections that haven't seen a stream in some time.

Note that for opening a  Stream, the Swarm will always prefer a direct connection over a Relayed connection as implemented in https://github.com/libp2p/go-libp2p-swarm/pull/233.